### PR TITLE
Include escaping of backslash char e.g. windows paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ In the opposite direction line breaks will be correctly escaped but the generato
 
 ## Author
 
-- Tnarik Innael (@tnarik)
+- Stuart Stephen (@mrswadge)
+- Tnarik Innael (@tnarik) : forked at [f08b23a1341569f576eb4cf859f59350f58bd1c3](https://github.com/tnarik/proper_properties/commit/f08b23a1341569f576eb4cf859f59350f58bd1c3)
 - Jonas Thiel (@jonasthiel) : [original project](https://github.com/jnbt/java-properties) upto [1f2c4b008d69d0eae1084b1adfdea814e2b29899](https://github.com/tnarik/proper_properties/commit/1f2c4b008d69d0eae1084b1adfdea814e2b29899)
 
 ## References

--- a/lib/proper_properties/encoding/special_chars.rb
+++ b/lib/proper_properties/encoding/special_chars.rb
@@ -10,7 +10,8 @@ module ProperProperties
         "\t" => '\\t',
         "\r" => '\\r',
         "\n" => '\\n',
-        "\f" => '\\f'
+        "\f" => '\\f',
+        "\\" => '\\\\'
       }.freeze
 
       # Lookup table to remove escaping from special chars


### PR DESCRIPTION
UNC paths need escaping. e.g. \\\\machine\\folder should be defined as \\\\\\\\machine\\\\folder